### PR TITLE
fix: repair pnpm run setup migrate and minio bucket steps

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -9,7 +9,7 @@
     "prisma:push": "npx prisma db push",
     "prisma:studio": "npx prisma studio",
     "prisma:migrate:dev": "npx prisma migrate dev && npm run prisma:generate && npm run prisma:seed",
-    "prisma:migrate:deploy": "npx prisma migrate deploy",
+    "prisma:migrate:deploy": "dotenv-flow -p ../.. -- npx prisma migrate deploy",
     "prisma:seed": "npx prisma db seed",
     "prisma:seed:reset": "npx prisma migrate reset --force && npx prisma db seed",
     "prisma:seed:dev": "dotenv-flow -p ../.. -- npx prisma db seed",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "prisma:studio": "pnpm -F @idea/api studio",
     "prisma:generate": "pnpm -F @idea/api prisma:generate",
     "migrate:dev": "pnpm -F @idea/api prisma:migrate:dev",
-    "migrate:deploy": "pnpm -F @idea/api migrate:deploy",
+    "migrate:deploy": "pnpm -F @idea/api prisma:migrate:deploy",
     "start": "turbo run start",
     "clean": "turbo run clean",
     "test": "turbo run test",

--- a/scripts/development/setup.sh
+++ b/scripts/development/setup.sh
@@ -105,13 +105,13 @@ echo "📦 Creating default MinIO bucket..."
 BUCKET_NAME="assets-idea-forge-dev"
 
 # Configure mc alias inside the running MinIO container
-docker exec $DOCKER_CONTAINER_NAME-minio mc alias set local http://localhost:9000 minioadmin minioadmin 2>/dev/null || true
+docker exec ${DOCKER_CONTAINER_NAME}-minio-1 mc alias set local http://localhost:9000 minioadmin minioadmin 2>/dev/null || true
 
 # Create bucket (ignore if exists)
-docker exec $DOCKER_CONTAINER_NAME-minio mc mb --ignore-existing local/$BUCKET_NAME 2>/dev/null || true
+docker exec ${DOCKER_CONTAINER_NAME}-minio-1 mc mb --ignore-existing local/$BUCKET_NAME 2>/dev/null || true
 
 # Set bucket policy to public (allow read access)
-docker exec $DOCKER_CONTAINER_NAME-minio mc anonymous set download local/$BUCKET_NAME 2>/dev/null || true
+docker exec ${DOCKER_CONTAINER_NAME}-minio-1 mc anonymous set download local/$BUCKET_NAME 2>/dev/null || true
 
 if [ $? -eq 0 ]; then
     echo "✅ MinIO bucket '$BUCKET_NAME' created and configured successfully"


### PR DESCRIPTION
`pnpm run setup` fails on a fresh clone due to three script bugs:

1. Root `migrate:deploy` calls `pnpm -F @idea/api migrate:deploy`, but the api script is named `prisma:migrate:deploy` → 'no such script'.
2. `prisma:migrate:deploy` runs bare `npx prisma migrate deploy` without loading root `.env` → `DATABASE_URL` undefined (P1012). Added `dotenv-flow -p ../..`.
3. setup.sh uses `$DOCKER_CONTAINER_NAME-minio`, but compose names it `<project>-minio-1` → bucket step silently skipped.

All three verified locally; `pnpm run migrate:deploy` and the MinIO bucket creation now succeed.