### PR TITLE
fix: guard toggleTaskList in content type menu to prevent crash on select

### DIFF
--- a/apps/client/src/editor/bubble-menus/text-menu/content-type-menu/useContentType.tsx
+++ b/apps/client/src/editor/bubble-menus/text-menu/content-type-menu/useContentType.tsx
@@ -67,7 +67,12 @@ export const useContentType = (editor: Editor | null) => {
         Icon: () => <ListTodo className="h-4 w-4" />,
         label: t("To-do list"),
         description: t("Track tasks with a to-do list."),
-        disabled: () => !editor.can().toggleTaskList(),
+        disabled: () => {
+          const can = editor.can() as ReturnType<Editor["can"]> & {
+            toggleTaskList?: () => boolean;
+          };
+          return typeof can.toggleTaskList !== "function" || !can.toggleTaskList();
+        },
         isActive: () => editor.isActive("taskList"),
         onClick: () => editor.chain().focus().toggleTaskList().run(),
       },


### PR DESCRIPTION
Selecting all text (or a multi-node selection) crashes the editor with `editor.can(...).toggleTaskList is not a function` from `ContentTypeMenu` (#30). The `disabled` callback for the To-do list option assumed `toggleTaskList` is always present on the command chain, so it throws whenever that command is not available.

This guards the call by checking the method exists before invoking it, matching how the reporter suggested. When the command is missing the option is treated as disabled instead of throwing; behavior is unchanged when it is present.

Note: I could not run the full monorepo build locally (it needs Docker/pnpm workspace setup), but the change is a single self-contained guard in `useContentType.tsx`.

Closes #30